### PR TITLE
ローカルの実行で Fake として Minio を使用可能にする

### DIFF
--- a/app/backend/src/ScoreHistoryApi/Controllers/ScoresController.cs
+++ b/app/backend/src/ScoreHistoryApi/Controllers/ScoresController.cs
@@ -439,7 +439,7 @@ namespace ScoreHistoryApi.Controllers
 
         [HttpPatch]
         [Route("user/{scoreId:guid}/access")]
-        public async Task<IActionResult> SetAccessAsync([FromRoute(Name = "id")] Guid scoreId, PatchScoreAccess access)
+        public async Task<IActionResult> SetAccessAsync([FromRoute(Name = "scoreId")] Guid scoreId, PatchScoreAccess access)
         {
             var authorizerData = this.GetAuthorizerData();
             var ownerId = authorizerData.Sub;

--- a/app/backend/src/ScoreHistoryApi/Factories/S3ClientFactory.cs
+++ b/app/backend/src/ScoreHistoryApi/Factories/S3ClientFactory.cs
@@ -3,6 +3,7 @@ using System.Net;
 using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
+using ScoreHistoryApi.Logics;
 
 namespace ScoreHistoryApi.Factories
 {
@@ -37,6 +38,8 @@ namespace ScoreHistoryApi.Factories
             }
         }
 
+        public bool UseMinio { get; set; } = false;
+
         public AWSCredentials Credentials { get; set; }
 
         public S3ClientFactory SetRegionSystemName(string regionSystemName)
@@ -54,6 +57,12 @@ namespace ScoreHistoryApi.Factories
         public S3ClientFactory SetCredentials(AWSCredentials credentials)
         {
             Credentials = credentials;
+            return this;
+        }
+
+        public S3ClientFactory SetUseMinio(bool useMinio)
+        {
+            UseMinio = useMinio;
             return this;
         }
 
@@ -78,6 +87,10 @@ namespace ScoreHistoryApi.Factories
                 {
                     RegionEndpoint = region
                 };
+
+                if (UseMinio)
+                    return new MinioClient(config);
+
                 return new AmazonS3Client(config);
             }
 
@@ -92,10 +105,16 @@ namespace ScoreHistoryApi.Factories
 
                 if (Credentials is null)
                 {
+                    if (UseMinio)
+                        return new MinioClient(config);
+
                     return new AmazonS3Client(config);
                 }
                 else
                 {
+                    if (UseMinio)
+                        return new MinioClient(Credentials, config);
+
                     return new AmazonS3Client(Credentials, config);
                 }
             }

--- a/app/backend/src/ScoreHistoryApi/LocalStartup.cs
+++ b/app/backend/src/ScoreHistoryApi/LocalStartup.cs
@@ -39,6 +39,7 @@ namespace ScoreHistoryApi
                 new S3ClientFactory()
                     .SetEndpointUrl(new Uri(Configuration[EnvironmentNames.ScoreS3EndpointUrl]))
                     .SetCredentials(Configuration[EnvironmentNames.ScoreS3AccessKey],Configuration[EnvironmentNames.ScoreS3SecretKey])
+                    .SetUseMinio(true)
                     .Create());
             services.AddScoped<ScoreLogics>();
             services.AddScoped<ScoreItemLogics>();

--- a/app/backend/src/ScoreHistoryApi/MinioClient.cs
+++ b/app/backend/src/ScoreHistoryApi/MinioClient.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+namespace ScoreHistoryApi
+{
+    public class MinioClient : AmazonS3Client
+    {
+        public MinioClient(AWSCredentials credentials):base(credentials)
+        {
+
+        }
+        public MinioClient(AWSCredentials credentials, AmazonS3Config clientConfig):base(credentials,clientConfig)
+        {
+
+        }
+        public MinioClient(AmazonS3Config clientConfig):base(clientConfig)
+        {
+
+        }
+        public override Task<PutACLResponse> PutACLAsync(PutACLRequest request, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.FromResult(new PutACLResponse());
+        }
+    }
+}

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "cdk": "cdk",
     "deploy-api": "cdk deploy ScoreHistoryApiStack",
-    "deploy-backend": "cdk deploy ScoreHistoryBackendStack"
+    "deploy-backend": "cdk deploy ScoreHistoryBackendStack",
+    "build-api": "pwsh ../app/backend/build.ps1"
   },
   "devDependencies": {
     "@aws-cdk/assert": "1.95.1",


### PR DESCRIPTION
ローカルで実行する際に ACL を設定しようとすると例外が発生するので、処理を無視する Client を追加する