### PR TITLE
update-annotaion-lock

### DIFF
--- a/app/backend/src/ScoreHistoryApi/Logics/DynamoDb/PropertyNames/ItemMainPn.cs
+++ b/app/backend/src/ScoreHistoryApi/Logics/DynamoDb/PropertyNames/ItemMainPn.cs
@@ -11,6 +11,10 @@ namespace ScoreHistoryApi.Logics.DynamoDb.PropertyNames
         public const string SortKey = "s";
         /// <summary>楽観ロック</summary>
         public const string Lock = "l";
+        /// <summary>トランザクションタイムアウト</summary>
+        public const string TransactionTimeout = "xt";
+        /// <summary>トランザクションスタート</summary>
+        public const string TransactionStart = "xs";
         /// <summary>データ構造のバージョン</summary>
         public const string Ver = "v";
         /// <summary>楽譜に含まれるアイテムのトータルサイズ</summary>

--- a/app/backend/src/ScoreHistoryApi/Logics/DynamoDb/PropertyNames/ScoreMainPn.cs
+++ b/app/backend/src/ScoreHistoryApi/Logics/DynamoDb/PropertyNames/ScoreMainPn.cs
@@ -18,6 +18,10 @@ namespace ScoreHistoryApi.Logics.DynamoDb.PropertyNames
         public const string Access = "as";
         /// <summary>楽観ロック</summary>
         public const string Lock = "l";
+        /// <summary>トランザクションタイムアウト</summary>
+        public const string TransactionTimeout = "xt";
+        /// <summary>トランザクションスタート</summary>
+        public const string TransactionStart = "xs";
         /// <summary>データ構造のバージョン</summary>
         public const string Ver = "v";
 

--- a/app/backend/src/ScoreHistoryApi/Logics/Scores/Initializer.cs
+++ b/app/backend/src/ScoreHistoryApi/Logics/Scores/Initializer.cs
@@ -69,9 +69,12 @@ namespace ScoreHistoryApi.Logics.Scores
         {
             var partitionKey = PartitionPrefix.Score + _commonLogic.ConvertIdFromGuid(ownerId);
 
-            await PutAsync(_dynamoDbClient, ScoreTableName, partitionKey);
+            var newLockValue = _commonLogic.NewGuid();
+            var newLock = _commonLogic.ConvertIdFromGuid(newLockValue);
 
-            static async Task PutAsync(IAmazonDynamoDB client, string tableName, string partitionKey)
+            await PutAsync(_dynamoDbClient, ScoreTableName, partitionKey, newLock);
+
+            static async Task PutAsync(IAmazonDynamoDB client, string tableName, string partitionKey, string newLock)
             {
                 var request = new PutItemRequest()
                 {
@@ -80,7 +83,7 @@ namespace ScoreHistoryApi.Logics.Scores
                         [ScoreSummaryPn.PartitionKey] = new(partitionKey),
                         [ScoreSummaryPn.SortKey] = new(DynamoDbConstant.SummarySortKey),
                         [ScoreSummaryPn.ScoreCount] = new(){N = "0"},
-                        [ScoreSummaryPn.Lock] = new(){N = "0"}
+                        [ScoreSummaryPn.Lock] = new(){S = newLock}
                     },
                     TableName = tableName,
                     ExpressionAttributeNames = new Dictionary<string, string>()
@@ -113,10 +116,12 @@ namespace ScoreHistoryApi.Logics.Scores
         public async Task InitializeScoreItemAsync(Guid ownerId)
         {
             var partitionKey = PartitionPrefix.Item + _commonLogic.ConvertIdFromGuid(ownerId);
+            var newLockValue = _commonLogic.NewGuid();
+            var newLock = _commonLogic.ConvertIdFromGuid(newLockValue);
 
-            await PutAsync(_dynamoDbClient, ScoreItemTableName, partitionKey);
+            await PutAsync(_dynamoDbClient, ScoreItemTableName, partitionKey, newLock);
 
-            static async Task PutAsync(IAmazonDynamoDB client, string tableName, string partitionKey)
+            static async Task PutAsync(IAmazonDynamoDB client, string tableName, string partitionKey, string newLock)
             {
                 var request = new PutItemRequest()
                 {
@@ -126,7 +131,7 @@ namespace ScoreHistoryApi.Logics.Scores
                         [ItemSummaryPn.SortKey] = new(DynamoDbConstant.SummarySortKey),
                         [ItemSummaryPn.TotalSize] = new(){N = "0"},
                         [ItemSummaryPn.TotalCount] = new(){N = "0"},
-                        [ItemSummaryPn.Lock] = new(){N = "0"}
+                        [ItemSummaryPn.Lock] = new(){S = newLock},
                     },
                     TableName = tableName,
                     ExpressionAttributeNames = new Dictionary<string, string>()


### PR DESCRIPTION
Lock に使用する文字列を変更検知にも使いたいため UUID を文字列に変換した物に変更した
数値のインクリメントだと値の予想ができてしまうため
アノテーションの変更のロック処理も Lock の値とタイムアウトを複合して行う方法に変更